### PR TITLE
Update duck.py

### DIFF
--- a/src/dynamicTyping/python/duck.py
+++ b/src/dynamicTyping/python/duck.py
@@ -1,14 +1,4 @@
-from abc import ABCMeta, abstractmethod
-
-class Duck(metaclass=ABCMeta):
-  @abstractmethod
-  def dance(self): 
-    pass
-  @abstractmethod
-  def talk(self):
-    pass
-
-class Mallard(Duck):
+class Mallard:
   def dance(self):
     return " _/¯ "
   def talk(self):


### PR DESCRIPTION
I don't get why a reference to the abc package and the declaration of a Duck class are needed in order to showcase duck-typing in python.